### PR TITLE
Replaced "proxy" with "proxies" line 455

### DIFF
--- a/aqua.py
+++ b/aqua.py
@@ -452,7 +452,7 @@ class CF_Solver(CF_MetaData):
                     'sec-fetch-site': 'none',
                     **self.headers
                 },
-                proxy=self._proxy_dict(),
+                proxies=self._proxy_dict(),
                 timeout=10
             )
 


### PR DESCRIPTION
I just fixed the error

`Traceback (most recent call last):
  File "c:\Users\noaha\Downloads\Cloudflare-Bypass-main\Cloudflare-Bypass-main\example.py", line 4, in <module>
    cf = CF_Solver('https://discord.com')
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\Users\noaha\Downloads\Cloudflare-Bypass-main\Cloudflare-Bypass-main\aqua.py", line 439, in __init__
    self.client = httpx.Client(
                  ^^^^^^^^^^^^^
TypeError: Client.__init__() got an unexpected keyword argument 'proxy'`

I replaced
```python
proxy=self._proxy_dict(),
```

with 
```python
proxies=self._proxy_dict()
```

In the line 455